### PR TITLE
fix: Add TCP timeouts to fix the outages

### DIFF
--- a/crates/app/.cargo/config.toml
+++ b/crates/app/.cargo/config.toml
@@ -12,6 +12,10 @@ METRICS_URL = "https://metrics.example.com"
 WIFI_PASSWORD = "password-placeholder"
 WIFI_SSID = "ssid-placeholder"
 
+ESP_WIFI_CONFIG_COUNTRY_CODE = "NZ"
+ESP_WIFI_CONFIG_BEACON_TIMEOUT = "15"
+ESP_WIFI_CONFIG_AP_BEACON_TIMEOUT = "60"
+
 [build]
 rustflags = [
   "-C",

--- a/crates/app/src/data_recording.rs
+++ b/crates/app/src/data_recording.rs
@@ -4,6 +4,7 @@ use embassy_net::tcp::client::TcpClientState;
 use embassy_net::Stack;
 use embassy_net::{dns::DnsSocket, tcp::client::TcpClient};
 
+use embassy_time::Duration;
 use esp_hal::time::{now, Instant};
 use heapless::String;
 
@@ -23,6 +24,7 @@ use uom::si::{pressure::hectopascal, ratio::percent, thermodynamic_temperature::
 use crate::device_meta::DEVICE_LOCATION;
 use crate::meta::CARGO_PKG_VERSION;
 use crate::sensor_data::{Ads1115Data, Bme280Data};
+use crate::wifi::DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS;
 
 const METRICS_URL: &str = env!("METRICS_URL");
 //const GRAFANA_USER_NAME: &str = env!("GRAFANA_USER_NAME");
@@ -138,7 +140,10 @@ pub async fn send_metrics_to_server(
     let dns_socket = DnsSocket::new(stack);
 
     let tcp_client_state = TcpClientState::<1, 4096, 4096>::new();
-    let tcp_client = TcpClient::new(stack, &tcp_client_state);
+    let mut tcp_client = TcpClient::new(stack, &tcp_client_state);
+    tcp_client.set_timeout(Some(Duration::from_millis(
+        DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS,
+    )));
 
     debug!("Creating HTTP client ...");
     let mut client = HttpClient::new(&tcp_client, &dns_socket);

--- a/crates/app/src/logging.rs
+++ b/crates/app/src/logging.rs
@@ -310,7 +310,9 @@ async fn transmit_logs(logs: &[LogEntry], stack: Stack<'_>, url: &str) -> Result
 
     let tcp_client_state = TcpClientState::<1, 4096, 4096>::new();
     let mut tcp_client = TcpClient::new(stack, &tcp_client_state);
-    tcp_client.set_timeout(Some(Duration::from_millis(DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS)));
+    tcp_client.set_timeout(Some(Duration::from_millis(
+        DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS,
+    )));
 
     log_to_console(
         Level::Debug,

--- a/crates/app/src/logging.rs
+++ b/crates/app/src/logging.rs
@@ -12,6 +12,7 @@ use embassy_net::dns::DnsSocket;
 use embassy_net::tcp::client::TcpClient;
 use embassy_net::tcp::client::TcpClientState;
 use embassy_net::Stack;
+use embassy_time::Duration;
 use esp_hal::time::now;
 use heapless::String;
 use heapless::Vec;
@@ -31,6 +32,7 @@ use thiserror::Error;
 
 use crate::device_meta::DEVICE_LOCATION;
 use crate::device_meta::MAX_DEVICE_NAME_LENGTH;
+use crate::wifi::DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS;
 
 // Constants for buffer sizes
 const MAX_STORED_LOGS: usize = 100;
@@ -307,7 +309,8 @@ async fn transmit_logs(logs: &[LogEntry], stack: Stack<'_>, url: &str) -> Result
     let dns_socket = DnsSocket::new(stack);
 
     let tcp_client_state = TcpClientState::<1, 4096, 4096>::new();
-    let tcp_client = TcpClient::new(stack, &tcp_client_state);
+    let mut tcp_client = TcpClient::new(stack, &tcp_client_state);
+    tcp_client.set_timeout(Some(Duration::from_millis(DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS)));
 
     log_to_console(
         Level::Debug,

--- a/crates/app/src/sensor.rs
+++ b/crates/app/src/sensor.rs
@@ -503,7 +503,7 @@ async fn wait_for_pressure_sensor_voltage_to_stabilize(
         debug!("Pressure sensor voltage: {:.2} V", pressure_sensor_voltage);
 
         let diff = fabsf(EXPECTED_PRESSURE_SENSOR_VOLTAGE - pressure_sensor_voltage);
-        if diff < 0.5 {
+        if diff < 1.0 {
             stable_count += 1;
         } else {
             stable_count = 0;

--- a/crates/app/src/timing.rs
+++ b/crates/app/src/timing.rs
@@ -3,6 +3,7 @@ use core::fmt::Write;
 use embassy_net::tcp::client::TcpClientState;
 use embassy_net::Stack;
 use embassy_net::{dns::DnsSocket, tcp::client::TcpClient};
+use embassy_time::Duration;
 use esp_hal::time::now;
 use heapless::String;
 use log::{debug, error};
@@ -11,6 +12,7 @@ use reqwless::{headers::ContentType, request::RequestBuilder};
 use thiserror::Error;
 
 use crate::device_meta::DEVICE_LOCATION;
+use crate::wifi::DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS;
 
 const METRICS_URL: &str = env!("METRICS_URL");
 
@@ -48,7 +50,10 @@ pub async fn send_timing_data(stack: Stack<'_>, boot_count: u32) -> Result<(), E
 
     let dns_socket = DnsSocket::new(stack);
     let tcp_client_state = TcpClientState::<1, 4096, 4096>::new();
-    let tcp_client = TcpClient::new(stack, &tcp_client_state);
+    let mut tcp_client = TcpClient::new(stack, &tcp_client_state);
+    tcp_client.set_timeout(Some(Duration::from_millis(
+        DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS,
+    )));
 
     debug!("Creating HTTP client...");
     let mut client = HttpClient::new(&tcp_client, &dns_socket);

--- a/crates/app/src/wifi.rs
+++ b/crates/app/src/wifi.rs
@@ -63,6 +63,8 @@ const WIFI_CHECK_INTERVAL_MS: u64 = 50;
 /// Maximum number of consecutive connection failures before giving up
 const MAX_CONSECUTIVE_FAILURES: u8 = 2;
 
+pub const DEFAULT_TCP_TIMEOUT_IN_MILLISECONDS: u64 = 5000;
+
 /// Static cell for network stack resources
 static STACK_RESOURCES: StaticCell<StackResources<6>> = StaticCell::new();
 


### PR DESCRIPTION
The change to set the Wifi powersaving mode to none seems to have mostly fixed the problem, however we're still seeing issues where the device may timeout for an hour. This PR adds TCP timeouts in the hopes of detecting issues earlier and shutting the device down in that case.

references #36 #49